### PR TITLE
PKG-5680

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,15 +1,12 @@
 #!/bin/bash
 
-if [[ "${target_platform}" == "osx-arm64" ]]; then
-  go build -v -o $PREFIX/bin/go-licenses
-
-  # Build for osx-64 as this can also be run in cross-compilation mode.
-  GOARCH=amd64 go build -v -o go-licenses-native
-  ./go-licenses-native save . --save_path=./license-files
+if [[ "${target_platform}" == "win-64" ]]; then
+  go build -v -o $PREFIX/bin/go-licenses.exe
 else
-  go install -v github.com/google/go-licenses
-  go-licenses save . --save_path=./license-files
+  go build -v -o $PREFIX/bin/go-licenses
 fi
+
+go-licenses save . --save_path=./license-files
 
 # TODO: remove if not actually needed, see #6
 # rm -r ./license-files/github.com/google/licenseclassifier/licenses

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,29 +5,37 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://github.com/google/go-licenses/archive/refs/tags/v{{ version }}.tar.gz
-    sha256: 70c1ceb7c342ceb79b63a76caafb13ea3796a51715c742a482eb9d85277311e7
+  url: https://github.com/google/go-licenses/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 70c1ceb7c342ceb79b63a76caafb13ea3796a51715c742a482eb9d85277311e7
 
 build:
   number: 0
+  skip: true  # [s390x]
 
 requirements:
   build:
     - {{ compiler('go') }}
-    - posix  # [win]
   host:
   run:
     - go
 
 test:
+  requires:
+  source_files:
+    - LICENSE
+    - check.go
+    - e2e_test.go
+    - go.mod
+    - go.sum
+    - main.go
+    - report.go
+    - internal
+    - licenses
+    - testdata
   commands:
-    - git clone --depth=1 "https://github.com/google/go-licenses"
-    - cd go-licenses
     - go-licenses csv . | findstr "Apache-2.0 BSD-.-Clause MIT"             # [win]
     - go-licenses csv . | grep 'Apache-2\.0\|BSD-.-Clause\|MIT\|Unlicense'  # [not win]
-  requires:
-    - git
-    - go
+    - go test -v .                                                          # [not win]
 
 about:
   home: https://github.com/google/go-licenses
@@ -37,6 +45,12 @@ about:
     - LICENSE
     - license-files/
   summary: A tool to collect licenses from the dependency tree of a Go package in order to comply with redistribution terms.
+  description: |
+    go-licenses analyzes the dependency tree of a Go package/binary. It can output a report on the libraries used
+    and under what license they can be used. It can also collect all of the license documents, copyright notices and
+    source code into a directory in order to comply with license terms on redistribution.
+  doc_url: https://github.com/google/go-licenses/blob/master/README.md
+  dev_url: https://github.com/google/go-licenses
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
go-licenses 1.6.0

**Destination channel:** defaults

### Links

- [PKG-5680](https://anaconda.atlassian.net/browse/PKG-5680)
- [Upstream repository](https://github.com/google/go-licenses/tree/v1.6.0)
- [Upstream changelog/diff](https://github.com/google/go-licenses/compare/v1.5.0...v1.6.0)
- Relevant dependency PRs:
  - AnacondaRecipes/fzf-feedstock#1
  - AnacondaRecipes/go-activation-feedstock#1


### Explanation of changes:

- Build script now actually builds from source instead of installing latest binary from repo
- Depend on go compiler directly since activation scripts are currently not supported on all platforms
- Run full test suite


[PKG-5680]: https://anaconda.atlassian.net/browse/PKG-5680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ